### PR TITLE
Adapt #buildWidget on SpToploListAdapter to changed order of arguments passed to the node builder

### DIFF
--- a/src/Spec-Toplo/SpToploListAdapter.class.st
+++ b/src/Spec-Toplo/SpToploListAdapter.class.st
@@ -11,7 +11,7 @@ Class {
 SpToploListAdapter >> buildWidget [
 
 	^ ToListElement new
-		nodeBuilder: [ :node :holder |
+		nodeBuilder: [ :node :dataItem :holder |
 		  self newItemElementFor: node holder: holder ];
 		yourself
 ]


### PR DESCRIPTION
This pull request adapts #buildWidget on SpToploListAdapter to the changed order of the arguments passed to the node builder done in [Toplo commit 155ea61e77](https://github.com/pharo-graphics/Toplo/commit/155ea61e77fc20ee4c4e9636d4d2b8e70e87a0a6).