### PR TITLE
Fix #newItemElementFor:holder: on SpToploListAdapter to also use the model’s display value for the label when there are no icons

### DIFF
--- a/src/Spec-Toplo/SpToploListAdapter.class.st
+++ b/src/Spec-Toplo/SpToploListAdapter.class.st
@@ -34,7 +34,7 @@ SpToploListAdapter >> newItemElementFor: node holder: holder [
 
 	self model hasIcons ifFalse: [ 
 		^ node addChild:
-			(ToLabel text: holder dataItem asString)
+			(ToLabel text: (model displayValueFor: holder dataItem) asRopedText)
 				hMatchParent;
 				yourself ].
 


### PR DESCRIPTION
This pull request fixes `#newItemElementFor:holder:` on SpToploListAdapter to also use the model’s display value for the label when there are no icons.

The screenshots below show the window opened by the following before and after this fix, with the changes of [pull request #3](https://github.com/pharo-graphics/Spec-Toplo/pull/3) and [Bloc pull request #595](https://github.com/pharo-graphics/Bloc/pull/595) already applied:

```smalltalk
BlHost preferableHostClass: BlMorphicWindowHost.
(StSystemReporterPresenter newApplication:
	(SpApplication new useBackend: #Toplo; yourself)) open
```

**Before:**
<img width="560" src="https://github.com/user-attachments/assets/851e35eb-7c33-451a-970f-d4293c07cdf6">

**After:**
<img width="560" src="https://github.com/user-attachments/assets/43f83101-1ae8-4eb9-8b79-f65d00cee0dc">
