### PR TITLE
Fix backend adapter test

### DIFF
--- a/src/BaselineOfSpecToplo/BaselineOfSpecToplo.class.st
+++ b/src/BaselineOfSpecToplo/BaselineOfSpecToplo.class.st
@@ -16,6 +16,8 @@ BaselineOfSpecToplo >> baseline: spec [
 				package: 'Spec-Toplo' with: [ spec requires: #( 'Toplo' ) ];
 				package: 'Spec-Toplo-Tests'
 				with: [ spec requires: #( 'Spec-Toplo' ) ];
+				package: 'Spec-Toplo-Backend-Tests'
+				with: [ spec requires: #( 'Spec-Toplo' 'Spec-Toplo-Tests' ) ];
 				package: 'Spec-Toplo-Examples'
 				with: [ spec requires: #( 'Spec-Toplo' ) ];
 				package: 'Spec-Toplo-Examples-ToDoList'

--- a/src/Spec-Toplo-Backend-Tests/SpToploAbstractTextAdapter.extension.st
+++ b/src/Spec-Toplo-Backend-Tests/SpToploAbstractTextAdapter.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #SpToploAbstractTextAdapter }
+
+{ #category : #'*Spec-Toplo-Backend-Tests' }
+SpToploAbstractTextAdapter >> type: aString [ 
+	
+	^ self typeByChar: aString
+]

--- a/src/Spec-Toplo-Backend-Tests/SpToploGridAdapter.extension.st
+++ b/src/Spec-Toplo-Backend-Tests/SpToploGridAdapter.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #SpToploGridAdapter }
+
+{ #category : #'*Spec-Toplo-Backend-Tests' }
+SpToploGridAdapter >> extentOfChildAt: anInteger [
+
+	^ (self children at: anInteger) bounds extent
+]

--- a/src/Spec-Toplo-Backend-Tests/SpToploListAdapter.extension.st
+++ b/src/Spec-Toplo-Backend-Tests/SpToploListAdapter.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : #SpToploListAdapter }
+
+{ #category : #'*Spec-Toplo-Backend-Tests' }
+SpToploListAdapter >> typeForSearch: aString [
+	"Method for testing
+	equivalent to typeByChar: of SpToploAbstractTextAdapter"
+
+	widget requestFocus.
+	BlSpace simulateTextInput: aString on: widget
+]

--- a/src/Spec-Toplo-Backend-Tests/SpToploTreeAdapter.extension.st
+++ b/src/Spec-Toplo-Backend-Tests/SpToploTreeAdapter.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #SpToploTreeAdapter }
+
+{ #category : #'*Spec-Toplo-Backend-Tests' }
+SpToploTreeAdapter >> sendClickEventToRowAtPath: aCollection [
+
+	| position listItemElement |
+	position := (widget dataSource itemsAtPath: aCollection) anyOne position.
+	listItemElement := widget nodes at: position.
+	BlSpace simulateClickOn: listItemElement.
+	BlSpace pulseUntilEmptyTaskQueue: listItemElement space timeout: 200 milliSeconds
+]

--- a/src/Spec-Toplo-Backend-Tests/SpToploTreeAdapter.extension.st
+++ b/src/Spec-Toplo-Backend-Tests/SpToploTreeAdapter.extension.st
@@ -9,3 +9,36 @@ SpToploTreeAdapter >> sendClickEventToRowAtPath: aCollection [
 	BlSpace simulateClickOn: listItemElement.
 	BlSpace pulseUntilEmptyTaskQueue: listItemElement space timeout: 200 milliSeconds
 ]
+
+{ #category : #'*Spec-Toplo-Backend-Tests' }
+SpToploTreeAdapter >> sendClickWithShiftEventToRowAtPath: aCollection [
+
+	| position listItemElement aPosition |
+	position := (widget dataSource itemsAtPath: aCollection) anyOne position.
+	listItemElement := widget nodes at: position.
+	"we never know if an element was already layered out"
+	listItemElement topMostParent forceLayout.
+	aPosition := listItemElement bounds inSpace center.
+
+
+	BlSpace
+		simulateEvents: {
+				((BlMouseDownEvent button: BlMouseButton primary)
+					 position: aPosition;
+					 modifiers: (BlKeyModifiers
+							  shift: true
+							  ctrl: false
+							  alt: false
+							  cmd: false);
+					 yourself).
+				((BlMouseUpEvent button: BlMouseButton primary)
+					 position: aPosition;
+					 modifiers: (BlKeyModifiers
+							  shift: true
+							  ctrl: false
+							  alt: false
+							  cmd: false);
+					 yourself) }
+		on: listItemElement.
+	BlSpace pulseUntilEmptyTaskQueue: listItemElement space timeout: 200 milliSeconds
+]

--- a/src/Spec-Toplo-Backend-Tests/SpToploTreeTableAdapter.extension.st
+++ b/src/Spec-Toplo-Backend-Tests/SpToploTreeTableAdapter.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #SpToploTreeTableAdapter }
+
+{ #category : #'*Spec-Toplo-Backend-Tests' }
+SpToploTreeTableAdapter >> isRowMorphExpandableAt: anInteger [
+
+	(self model application propertyAt: #testBackend) waitUntilUIRedrawed.
+	^ (((self widget list nodeContainers at: anInteger) childWithId: #'start-container') childWithId: #arrowButton)
+		  childWithId: #unknown
+		  ifFound: [ ^ false ]
+		  ifNone: [ ^ true ]
+]

--- a/src/Spec-Toplo-Backend-Tests/ToTableElement.extension.st
+++ b/src/Spec-Toplo-Backend-Tests/ToTableElement.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #ToTableElement }
+
+{ #category : #'*Spec-Toplo-Backend-Tests' }
+ToTableElement >> showHeader [
+	^ showHeader
+]

--- a/src/Spec-Toplo-Backend-Tests/package.st
+++ b/src/Spec-Toplo-Backend-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Spec-Toplo-Backend-Tests' }

--- a/src/Spec-Toplo-Examples-MiniBrowser/SpToMiniBrowserEditorModel.class.st
+++ b/src/Spec-Toplo-Examples-MiniBrowser/SpToMiniBrowserEditorModel.class.st
@@ -1,0 +1,51 @@
+Class {
+	#name : #SpToMiniBrowserEditorModel,
+	#superclass : #Object,
+	#instVars : [
+		'selectedBehavior',
+		'selectedMethod',
+		'whenSelectedBehaviorChangedBlock',
+		'whenSelectedMethodChangedBlock'
+	],
+	#category : #'Spec-Toplo-Examples-MiniBrowser-Presenters'
+}
+
+{ #category : #accessing }
+SpToMiniBrowserEditorModel >> selectedBehavior [
+
+	^ selectedBehavior
+]
+
+{ #category : #accessing }
+SpToMiniBrowserEditorModel >> selectedBehavior: anObject [
+
+	selectedBehavior = anObject ifTrue: [ ^ self ].
+	selectedBehavior := anObject.
+	whenSelectedBehaviorChangedBlock ifNotNil: [ :block | block cull: selectedBehavior ]
+]
+
+{ #category : #accessing }
+SpToMiniBrowserEditorModel >> selectedMethod [
+
+	^ selectedMethod
+]
+
+{ #category : #accessing }
+SpToMiniBrowserEditorModel >> selectedMethod: anObject [
+
+	selectedMethod = anObject ifTrue: [ ^ self ].
+	selectedMethod := anObject.
+	whenSelectedMethodChangedBlock ifNotNil: [ :block | block cull: selectedMethod ]
+]
+
+{ #category : #accessing }
+SpToMiniBrowserEditorModel >> whenSelectedBehaviorChangedDo: aBlock [
+
+	whenSelectedBehaviorChangedBlock := aBlock 
+]
+
+{ #category : #accessing }
+SpToMiniBrowserEditorModel >> whenSelectedMethodChangedDo: aBlock [
+
+	whenSelectedMethodChangedBlock := aBlock 
+]

--- a/src/Spec-Toplo-Examples-MiniBrowser/SpToMiniBrowserEditorPresenter.class.st
+++ b/src/Spec-Toplo-Examples-MiniBrowser/SpToMiniBrowserEditorPresenter.class.st
@@ -1,0 +1,114 @@
+Class {
+	#name : #SpToMiniBrowserEditorPresenter,
+	#superclass : #SpPresenterWithModel,
+	#instVars : [
+		'notebook',
+		'methodCodePage',
+		'behaviorCodePage'
+	],
+	#category : #'Spec-Toplo-Examples-MiniBrowser-Presenters'
+}
+
+{ #category : #api }
+SpToMiniBrowserEditorPresenter >> clearInteractionModel [
+
+	self model selectedMethod: nil
+]
+
+{ #category : #layout }
+SpToMiniBrowserEditorPresenter >> defaultLayout [
+
+	^ SpBoxLayout newLeftToRight
+		  add: #notebook;
+		  yourself
+]
+
+{ #category : #layout }
+SpToMiniBrowserEditorPresenter >> initializeClassCodePage [
+
+	behaviorCodePage presenterProvider: [
+			| codePresenter |
+			codePresenter := self newCode.
+			self model whenSelectedBehaviorChangedDo: [ :behavior |
+					behavior
+						ifNil: [
+								behaviorCodePage title: 'New Class'.
+								codePresenter userActionDuring: [
+										codePresenter text: 'Object << #MyClass
+	slots: {};
+	package: ''_Unpackaged''' ] ]
+						ifNotNil: [
+								behaviorCodePage title: behavior printString.
+								codePresenter text: behavior definitionString copy ] ].
+			codePresenter ].
+	self setBehaviorCodePage: nil
+]
+
+{ #category : #layout }
+SpToMiniBrowserEditorPresenter >> initializeMethodCodePage [
+
+	methodCodePage title: ''.
+
+	self model whenSelectedMethodChangedDo: [ :method |
+			method
+				ifNil: [
+						notebook selectPage: behaviorCodePage.
+						(notebook pages includes: methodCodePage) ifTrue: [ notebook removePage: methodCodePage ] ]
+				ifNotNil: [
+						methodCodePage title: method selector.
+
+						(notebook pages includes: methodCodePage)
+							ifFalse: [ notebook addPage: methodCodePage ]
+							ifTrue: [  methodCodePage resetContent ].
+						notebook selectPage: methodCodePage ] ].
+
+
+	methodCodePage presenterProvider: [
+			| sourceText codePresenter |
+			codePresenter := self newCode.
+			sourceText := self model selectedBehavior sourceCodeAt: self model selectedMethod selector ifAbsent: [ '' ].
+
+			codePresenter userActionDuring: [
+					codePresenter beForBehavior: self model selectedBehavior.
+					codePresenter text: sourceText copy ].
+			codePresenter ].
+	^ methodCodePage
+]
+
+{ #category : #initialization }
+SpToMiniBrowserEditorPresenter >> initializePresenters [
+
+	super initializePresenters.
+	notebook := self newNotebook.
+	methodCodePage := self newNotebookPage.
+	behaviorCodePage := self newNotebookPage.
+	notebook addPage: behaviorCodePage.
+	notebook addPage: methodCodePage.
+	
+	notebook selectPage: behaviorCodePage.
+	self initializeClassCodePage.
+	self initializeMethodCodePage.
+]
+
+{ #category : #api }
+SpToMiniBrowserEditorPresenter >> setBehaviorCodePage: aBehaviorOrNil [
+
+	self model selectedBehavior: aBehaviorOrNil.
+	self setSelectedMethod: nil
+]
+
+{ #category : #layout }
+SpToMiniBrowserEditorPresenter >> setMethod: anAssociationClassSelector [
+
+	| behavior selector |
+	behavior := anAssociationClassSelector key.
+	selector := anAssociationClassSelector value.
+	self model selectedBehavior: behavior.
+	self model selectedMethod: behavior >> selector
+]
+
+{ #category : #api }
+SpToMiniBrowserEditorPresenter >> setSelectedMethod: aMethod [
+
+	self model selectedMethod: aMethod
+]

--- a/src/Spec-Toplo-Examples-MiniBrowser/SpToMiniBrowserEditorPresenter.class.st
+++ b/src/Spec-Toplo-Examples-MiniBrowser/SpToMiniBrowserEditorPresenter.class.st
@@ -28,15 +28,14 @@ SpToMiniBrowserEditorPresenter >> initializeClassCodePage [
 
 	behaviorCodePage presenterProvider: [
 			| codePresenter |
-			codePresenter := self newCode.
+			codePresenter := self newCodeEditor.
 			self model whenSelectedBehaviorChangedDo: [ :behavior |
 					behavior
 						ifNil: [
 								behaviorCodePage title: 'New Class'.
-								codePresenter userActionDuring: [
-										codePresenter text: 'Object << #MyClass
+								codePresenter text: 'Object << #MyClass
 	slots: {};
-	package: ''_Unpackaged''' ] ]
+	package: ''_Unpackaged''' ]
 						ifNotNil: [
 								behaviorCodePage title: behavior printString.
 								codePresenter text: behavior definitionString copy ] ].
@@ -59,18 +58,18 @@ SpToMiniBrowserEditorPresenter >> initializeMethodCodePage [
 
 						(notebook pages includes: methodCodePage)
 							ifFalse: [ notebook addPage: methodCodePage ]
-							ifTrue: [  methodCodePage resetContent ].
+							ifTrue: [ methodCodePage resetContent ].
 						notebook selectPage: methodCodePage ] ].
 
 
 	methodCodePage presenterProvider: [
 			| sourceText codePresenter |
-			codePresenter := self newCode.
+			codePresenter := self newCodeEditor.
 			sourceText := self model selectedBehavior sourceCodeAt: self model selectedMethod selector ifAbsent: [ '' ].
 
-			codePresenter userActionDuring: [
-					codePresenter beForBehavior: self model selectedBehavior.
-					codePresenter text: sourceText copy ].
+			codePresenter beForBehavior: self model selectedBehavior.
+			codePresenter text: sourceText copy.
+			codePresenter whenSubmitDo: [ :text | codePresenter interactionModel behavior compile: text ].
 			codePresenter ].
 	^ methodCodePage
 ]

--- a/src/Spec-Toplo-Examples-MiniBrowser/SpToMiniBrowserPresenter.class.st
+++ b/src/Spec-Toplo-Examples-MiniBrowser/SpToMiniBrowserPresenter.class.st
@@ -88,17 +88,16 @@ SpToMiniBrowserPresenter >> classColumnLayout [
 { #category : #selection }
 SpToMiniBrowserPresenter >> classSelectionChanged [
 
-	self refreshProtocolListFromSelectedClass
+	self refreshProtocolListFromSelectedClass.
+	codePresenter model selectedBehavior: classTree selectedItem
 ]
 
 { #category : #'private - refreshing' }
 SpToMiniBrowserPresenter >> clearCodePresenter [
 
 	codePresenter ifNil: [ ^ self ].
-	codePresenter userActionDuring: [
-			codePresenter
-				clearInteractionModel;
-				text: '' ]
+	codePresenter
+				clearInteractionModel
 ]
 
 { #category : #'private - refreshing' }
@@ -179,9 +178,7 @@ SpToMiniBrowserPresenter >> initializePresenters [
 		                display: [ :anAssociation | anAssociation value asString ];
 		                yourself.
 
-	codePresenter := self newCode
-		                 text: '';
-		                 yourself.
+	codePresenter := SpToMiniBrowserEditorPresenter on: SpToMiniBrowserEditorModel new.
 
 	classSideCheckBox := self newCheckBox
 		                     label: 'Class side';
@@ -352,13 +349,7 @@ SpToMiniBrowserPresenter >> selectorSelectionChanged [
 { #category : #'private - refreshing' }
 SpToMiniBrowserPresenter >> showSourceForSelectorAssociation: anAssociation [
 
-	| behavior selector sourceText |
-	behavior := anAssociation key.
-	selector := anAssociation value.
-	sourceText := behavior sourceCodeAt: selector ifAbsent: [ '' ].
-	codePresenter userActionDuring: [
-			codePresenter beForBehavior: behavior.
-			codePresenter text: sourceText copy ]
+	codePresenter setMethod: anAssociation
 ]
 
 { #category : #'private - packages' }

--- a/src/Spec-Toplo-Tests/SpAbstractEasyListViewPresenter.extension.st
+++ b/src/Spec-Toplo-Tests/SpAbstractEasyListViewPresenter.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #SpAbstractEasyListViewPresenter }
+
+{ #category : #'*Spec-Toplo-Tests' }
+SpAbstractEasyListViewPresenter >> unselectIndex: anInteger [ 
+	
+	contentView unselectIndex: anInteger
+]

--- a/src/Spec-Toplo-Tests/SpToploBackendForTest.class.st
+++ b/src/Spec-Toplo-Tests/SpToploBackendForTest.class.st
@@ -71,6 +71,7 @@ SpToploBackendForTest >> runTest: aBlock [
 
 	app := SpApplication new.
 	app useBackend: #Toplo.
+	app propertyAt: #testBackend put: self.
 	aBlock value
 ]
 

--- a/src/Spec-Toplo/SpToploGridAdapter.class.st
+++ b/src/Spec-Toplo/SpToploGridAdapter.class.st
@@ -17,7 +17,8 @@ SpToploGridAdapter >> addChildElement: aToLabel with: aSpGridConstraints [
 SpToploGridAdapter >> addConstraints: constraints toChild: childBlElement [
 
 	childBlElement constraintsDo: [ :c |
-			self model layout isColumnHomogeneous ifFalse: [ childBlElement fitContent ].
+			(self model layout isKindOf: SpGridLayout) ifTrue: [
+				self model layout isColumnHomogeneous ifFalse: [ childBlElement fitContent ] ].
 			constraints span ifNotNil: [
 					c grid horizontal span: constraints span x.
 					c grid vertical span: constraints span y ] ].

--- a/src/Spec-Toplo/SpToploGridAdapter.class.st
+++ b/src/Spec-Toplo/SpToploGridAdapter.class.st
@@ -13,7 +13,7 @@ SpToploGridAdapter >> addChildElement: aToLabel with: aSpGridConstraints [
 	widget addChild: aToLabel
 ]
 
-{ #category : #'instance creation' }
+{ #category : #adding }
 SpToploGridAdapter >> addConstraints: constraints toChild: childBlElement [
 
 	childBlElement constraintsDo: [ :c |

--- a/src/Spec-Toplo/SpToploGridAdapter.class.st
+++ b/src/Spec-Toplo/SpToploGridAdapter.class.st
@@ -30,9 +30,9 @@ SpToploGridAdapter >> newToploWidget [
 	| gridLayout |
 	gridLayout := BlGridLayout horizontal.
 	gridLayout columnCount:
-		(layout children values collect: [ :value | value position x ]) max.
+		((layout children values collect: [ :value | value position x ]) ifNotEmpty: [ :col | col max ] ifEmpty: [ 0 ]).
 	gridLayout rowCount:
-		(layout children values collect: [ :value | value position y ]) max.
+		((layout children values collect: [ :value | value position y ]) ifNotEmpty: [ :col | col max ] ifEmpty: [ 0 ]).
 	^ ToPane new
 		  layout: gridLayout;
 		  yourself

--- a/src/Spec-Toplo/SpToploGridAdapter.class.st
+++ b/src/Spec-Toplo/SpToploGridAdapter.class.st
@@ -16,6 +16,10 @@ SpToploGridAdapter >> addChildElement: aToLabel with: aSpGridConstraints [
 { #category : #'instance creation' }
 SpToploGridAdapter >> addConstraints: constraints toChild: childBlElement [
 
+	childBlElement constraintsDo: [ :c |
+			constraints span ifNotNil: [
+					c grid horizontal span: constraints span x.
+					c grid vertical span: constraints span y ] ].
 	^ childBlElement
 ]
 

--- a/src/Spec-Toplo/SpToploGridAdapter.class.st
+++ b/src/Spec-Toplo/SpToploGridAdapter.class.st
@@ -17,6 +17,7 @@ SpToploGridAdapter >> addChildElement: aToLabel with: aSpGridConstraints [
 SpToploGridAdapter >> addConstraints: constraints toChild: childBlElement [
 
 	childBlElement constraintsDo: [ :c |
+			self model layout isColumnHomogeneous ifFalse: [ childBlElement fitContent ].
 			constraints span ifNotNil: [
 					c grid horizontal span: constraints span x.
 					c grid vertical span: constraints span y ] ].

--- a/src/Spec-Toplo/SpToploLabelAdapter.class.st
+++ b/src/Spec-Toplo/SpToploLabelAdapter.class.st
@@ -10,6 +10,15 @@ Class {
 }
 
 { #category : #accessing }
+SpToploLabelAdapter >> backgroundColor [
+
+	^ self widget attributesBuilder attributes
+		  detect: [ :att | att isKindOf: BlTextBackgroundAttribute ]
+		  ifFound: [ :attribute | attribute paint ]
+		  ifNone: [ ^ nil ]
+]
+
+{ #category : #accessing }
 SpToploLabelAdapter >> beJustifyCenter [
 	"not implemented yet"
 ]
@@ -45,14 +54,22 @@ SpToploLabelAdapter >> subscribeToPresenter [
 	model whenLabelChangedDo: [ self updateLabel ]
 ]
 
-{ #category : #'updating widget' }
+{ #category : #initialization }
 SpToploLabelAdapter >> updateAll [
 
 	super updateAll.
 
 	self
 		updateLabel;
-		updateMenu
+		updateMenu;
+		updateBackgroundColor
+]
+
+{ #category : #'updating widget' }
+SpToploLabelAdapter >> updateBackgroundColor [
+
+	self model displayBackgroundColor ifNotNil: [ :backgroundColorAction |
+		self widget attributesBuilder background: backgroundColorAction value ]
 ]
 
 { #category : #'updating widget' }

--- a/src/Spec-Toplo/SpToploNotebookAdapter.class.st
+++ b/src/Spec-Toplo/SpToploNotebookAdapter.class.st
@@ -114,7 +114,19 @@ SpToploNotebookAdapter >> subscribeToPresenter [
 	super subscribeToPresenter.
 	model
 		whenPagesChangedDo: [ :pages | self updatePagesWith: pages ];
-		whenSelectedPageChangedDo: [ :page | self selectPage: page ]
+		whenSelectedPageChangedDo: [ :page | self selectPage: page ];
+		whenPageRemovedDo: [ :page | "" ]
+]
+
+{ #category : #initialization }
+SpToploNotebookAdapter >> subscribeToWidget [
+
+	super subscribeToWidget.
+
+	widget itemList addEventHandlerOn: ToListPrimarySelectionChangedEvent do: [ :event |
+			event selectedIndexes
+				ifEmpty: [ self model selectPage: nil ]
+				ifNotEmpty: [ self model selectPage: (self model pages at: event selectedIndexes first) ] ]
 ]
 
 { #category : #updating }
@@ -122,7 +134,6 @@ SpToploNotebookAdapter >> updatePageContent: aPage [
 
 	(self pageWithModel: aPage) invalidate.
 	aPage = self presenter selectedPage ifFalse: [ ^ self ].
-	self flag: #toBeImplemented.
 	self updatePageIndex: self model selectedPageIndex
 ]
 
@@ -130,14 +141,15 @@ SpToploNotebookAdapter >> updatePageContent: aPage [
 SpToploNotebookAdapter >> updatePageIndex: anInteger [
 
 	| newPage widgetPage |
+
 	newPage := self model pages at: anInteger.
 	widgetPage := self widgetPageAtIndex: anInteger.
-
-	widgetPage paneBuilder: [ :pane |
-		pane addChild: (self buildContentForPage: newPage) ].
+	widgetPage paneBuilder: [ :pane | pane addChild: (self buildContentForPage: newPage) ].
 	widgetPage bodyPane: nil.
-	self widget itemList group notifyChanged.
-
+	self widget itemList dataSource notifyChanged.
+	(self widget itemList isSelectedAtPosition: anInteger) ifFalse: [ ^ self ].
+	self widget body removeChildren.
+	(widgetPage paneBuilder value: self widget body)
 ]
 
 { #category : #factory }
@@ -147,13 +159,10 @@ SpToploNotebookAdapter >> updatePagesWith: aCollection [
 	self widget ifNil: [ ^ self ].
 
 	pagesToRemove := self widget dataAccessor reject: [ :tabButton |
-		                 aCollection anySatisfy: [ :page |
-			                 page = (self modelOfTab: tabButton) ] ].
+		                 aCollection anySatisfy: [ :page | page = (self modelOfTab: tabButton) ] ].
 	pagesToRemove do: [ :tabButton | self widget removeItem: tabButton ].
 	aCollection
-		reject: [ :page |
-				self widget dataAccessor anySatisfy: [ :p |
-					(self modelOfTab: p) = page ] ]
+		reject: [ :page | self widget dataAccessor anySatisfy: [ :p | (self modelOfTab: p) = page ] ]
 		thenDo: [ :page | self widget addTabItemData: page ]
 ]
 

--- a/src/Spec-Toplo/SpToploSliderAdapter.class.st
+++ b/src/Spec-Toplo/SpToploSliderAdapter.class.st
@@ -6,6 +6,35 @@ Class {
 
 { #category : #factory }
 SpToploSliderAdapter >> buildWidget [
+	
+	^ ToBasicHorizontalSlider new
+		  minValue: self model min;
+		  maxValue: self model max;
+		  yourself
+]
 
-	^ ToProgressBar new
+{ #category : #initialization }
+SpToploSliderAdapter >> subscribeToPresenter [
+
+	super subscribeToPresenter.
+	self presenter whenValueChangedDo: [ :newValue | self widget setValue: newValue ].
+	self presenter whenMinChangedDo: [ :newValue | self widget minValue: newValue ].
+	self presenter whenMaxChangedDo: [ :newValue | self widget maxValue: newValue ].
+	self presenter whenQuantumChangedDo: [ :newValue | self widget quantum: newValue ].
+	self presenter whenLabelChangedDo: [ :newLabel | self widget label: newLabel ].
+	self presenter whenAbsoluteValueChangedDo: [ :newValue | self widget setValue: newValue ]
+]
+
+{ #category : #debug }
+SpToploSliderAdapter >> widgetAbsoluteValue [
+
+	| current total |
+	current := self widget currentValue - self widget minValue.
+	total := self widget maxValue - self widget minValue.
+	^ (current / total) asFloat
+]
+
+{ #category : #debug }
+SpToploSliderAdapter >> widgetValue [
+	^ self widget currentValue
 ]

--- a/src/Spec-Toplo/SpToploTTreeHelper.trait.st
+++ b/src/Spec-Toplo/SpToploTTreeHelper.trait.st
@@ -45,13 +45,13 @@ SpToploTTreeHelper >> transferSelectionChange: evt [
 
 	| currentPaths selectedIndex |
 	self suspendUpdateSelectionDuring: [
-			evt selectedIndexes ifEmpty: [ "UI is not ready?" ^ self ].
+			evt selectedIndexes ifEmpty: [ "The user unselect everything"
+					self model selection selectPaths: {  }.
+					^ self ].
 			selectedIndex := evt selectedIndexes first.
 
-			selectedIndex > evt currentTarget dataSource size ifTrue: [
-				^ self flag: #'might be a bug' ].
-			currentPaths := (evt currentTarget dataSource pathOfIndex:
-				                 selectedIndex) asArray.
+			selectedIndex > evt currentTarget dataSource size ifTrue: [ ^ self flag: #'might be a bug' ].
+			currentPaths := (evt currentTarget dataSource pathOfIndex: selectedIndex) asArray.
 			currentPaths = self model selection selectedPaths ifTrue: [ ^ self ].
 
 			self model selection selectPaths: { currentPaths } ]

--- a/src/Spec-Toplo/SpToploTableAdapter.class.st
+++ b/src/Spec-Toplo/SpToploTableAdapter.class.st
@@ -58,6 +58,12 @@ SpToploTableAdapter >> buildWidget [
 	^ widget
 ]
 
+{ #category : #accessing }
+SpToploTableAdapter >> columns [
+
+	^ self widget columns
+]
+
 { #category : #initialization }
 SpToploTableAdapter >> initialize [
 

--- a/src/Spec-Toplo/SpToploTableAdapter.class.st
+++ b/src/Spec-Toplo/SpToploTableAdapter.class.st
@@ -73,6 +73,12 @@ SpToploTableAdapter >> initialize [
 	activatedList := Set new
 ]
 
+{ #category : #testing }
+SpToploTableAdapter >> isShowColumnHeaders [
+	
+	^ self widget showHeader
+]
+
 { #category : #initialization }
 SpToploTableAdapter >> subscribeToPresenter [
 

--- a/src/Spec-Toplo/SpToploTextInputFieldEventHandler.class.st
+++ b/src/Spec-Toplo/SpToploTextInputFieldEventHandler.class.st
@@ -131,12 +131,12 @@ SpToploTextInputFieldEventHandler >> textInsertedEvent: evt [
 SpToploTextInputFieldEventHandler >> textReplacedEvent: evt [
 
 	isSuspended ifTrue: [ ^ self ].
-	
-	text := evt text copy.
 
-	self
-		updateWidgetWithAsterisks;
-		setPresenterText
+	text := evt text copy.
+	self isPassword
+		ifTrue: [ self updateWidgetWithAsterisks ]
+		ifFalse: [ adapter setWidgetString: text ].
+	self setPresenterText
 ]
 
 { #category : #private }

--- a/src/Spec-Toplo/SpToploTreeAdapter.class.st
+++ b/src/Spec-Toplo/SpToploTreeAdapter.class.st
@@ -59,12 +59,9 @@ SpToploTreeAdapter >> initialize [
 ]
 
 { #category : #testing }
-SpToploTreeAdapter >> isExpanded: item [
+SpToploTreeAdapter >> isExpanded: aPath [
 
-	^ widget dataSource collection
-		detect: [ :each | each dataItem = item ]
-		ifFound: [ :dataItem | dataItem isExpanded ]
-		ifNone: [ false ]
+	^ (widget dataSource itemsAtPath: aPath) first isExpanded
 ]
 
 { #category : #private }


### PR DESCRIPTION
Continuation of https://github.com/pharo-graphics/Spec-Toplo/pull/93

- [x] enable tests that uses `isRowMorphExpandableAt:`
- [x] add first version of Slider 
- [x] Tree `isExpanded` method is incorrect and breaks tests such as `testCollapseAll`
- [x] Improve test for header of table 
- [x] Improve grid Layout support 
- [x] fix unselect all items of a tree
- [x] Improve MiniBrowser and fix update tab of notebook 